### PR TITLE
Fix json to string using json.dumps

### DIFF
--- a/back/handler.py
+++ b/back/handler.py
@@ -78,7 +78,7 @@ def addLog(req_json: dict):
     ts = req_json["timestamp"]
     uname = db.getUserName(sid)
 
-    db.addLog(sid, isent, ts, str(ext))
+    db.addLog(sid, isent, ts, json.dumps(ext))
 
     res = json.dumps({"SID": sid, "timestamp": int(time.time())})
     return res


### PR DESCRIPTION
JSONをstrでパースしたらJSONに戻せなかったのでjson.dumpsに変えました。