### PR TITLE
Update nfc reader to support python3

### DIFF
--- a/bin/nfc_reader.py
+++ b/bin/nfc_reader.py
@@ -13,15 +13,15 @@ def on_connect(tag):
             if data[0:4] == "1000":
                 sid = data[4:11]
                 if sid[0] == "1":
-                    print "student s" + sid
+                    print("student s" + sid)
                 elif sid[0] == "5":
-                    print "student m" + sid
+                    print("student m" + sid)
                 elif sid[0] == "8":
-                    print "student d" + sid
+                    print("student d" + sid)
             else:
-                print "univ " + data
+                print("univ " + data)
         except Exception as e:
-            print "general " + "" . join(['%02x' % s for s in tag.idm])
+            print("general " + "" . join(['%02x' % s for s in tag.idm]))
 
 clf = nfc.ContactlessFrontend('usb')
 try:

--- a/server/handler/socket.go
+++ b/server/handler/socket.go
@@ -29,7 +29,7 @@ var clients = []*websocket.Conn{}
 func ReadCard(d *sql.DB) {
 	for {
 		var resdat IDCardInfo
-		dat, err := exec.Command("python2.7", "nfc_reader.py").Output()
+		dat, err := exec.Command("python3", "nfc_reader.py").Output()
 		if err != nil {
 			log.Printf("socket: nfc reader error : %v\n", err)
 


### PR DESCRIPTION
Update nfc_reader.py to support python3.
close #135 close #167

嘘でしょ…printに()をつけるだけでpython3に移行できてしまった…