### PR TITLE
ビルド時のブランチ名のパースを修正

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 git remote set-url origin https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-BRANCHNAME=${GITHUB_REF##*/}
+BRANCHNAME=${GITHUB_REF#refs/heads/}
 
 if [ "${BRANCHNAME}" = "master" ]; then
 # If branch is master, version up normally.


### PR DESCRIPTION
スラッシュが含まれるブランチ名の場合、`build.sh`が正しく動作しないため修正

参考: https://stackoverflow.com/questions/58033366/how-to-get-current-branch-within-github-actions