### PR TITLE
fix: 月次ログが送信されない問題を修正

### DIFF
--- a/server/db/user.go
+++ b/server/db/user.go
@@ -92,7 +92,17 @@ func ForceLeave(d *sql.DB) error {
 	count := 0
 
 	// Select all users who are currently in the room
-	rows, err := tx.Query(`SELECT ainsID FROM log WHERE isEnter=1 AND time<?`, yesterdayStartTime)
+	rows, err := tx.Query(`
+       SELECT ainsID
+       FROM log l
+       WHERE time = (
+               SELECT MAX(time)
+               FROM log
+               WHERE ainsID = l.ainsID
+                 AND time >= ?
+       )
+       AND isEnter = 1
+    `, yesterdayStartTime)
 	if err != nil {
 		return fmt.Errorf("failed to query users in room: %w", err)
 	}

--- a/server/utils/csvexport.go
+++ b/server/utils/csvexport.go
@@ -16,9 +16,11 @@ const (
 	TimestampMillisecondDivisor = 1000
 )
 
+const Enter = 1
+
 // csvExport exports log data as CSV text
 func csvExport(d *sql.DB) (string, error) {
-	rows, err := d.Query(`select time,log.sid,name,log.isenter,ext from log,users where log.sid=users.sid`)
+	rows, err := d.Query(`SELECT log.time,log.ainsID,users.name,log.isenter,log.ext FROM log,users WHERE log.ainsID=users.ainsID`)
 	if err != nil {
 		return "", err
 	}
@@ -27,18 +29,18 @@ func csvExport(d *sql.DB) (string, error) {
 	for rows.Next() {
 		var (
 			ts      int64
-			sid     string
+			ainsID     string
 			name    string
-			isenter int64
+			isEnter int64
 			ext     string
 		)
-		if err := rows.Scan(&ts, &sid, &name, &isenter, &ext); err != nil {
+		if err := rows.Scan(&ts, &ainsID, &name, &isEnter, &ext); err != nil {
 			return "", err
 		}
 
 		datefmted := time.Unix(ts/TimestampMillisecondDivisor, 0).Format("2006-01-02 15:04:05")
 		entstr := "Leave"
-		if isenter == 1 {
+		if isEnter == Enter {
 			entstr = "Enter"
 		}
 
@@ -61,9 +63,9 @@ func csvExport(d *sql.DB) (string, error) {
 			}
 			mess = strings.Replace(mess, "\"", "\"\"", -1)
 
-			csv += fmt.Sprintf("%v,%v,%v,%v,%v,\"%v\"\n", datefmted, sid, name, entstr, useage, mess)
+			csv += fmt.Sprintf("%v,%v,%v,%v,%v,\"%v\"\n", datefmted, ainsID, name, entstr, useage, mess)
 		} else {
-			csv += fmt.Sprintf("%v,%v,%v,%v,,\n", datefmted, sid, name, entstr)
+			csv += fmt.Sprintf("%v,%v,%v,%v,,\n", datefmted, ainsID, name, entstr)
 		}
 	}
 	err = rows.Close()
@@ -101,7 +103,7 @@ func sendMonthlyLog(d *sql.DB) error {
 		return err
 	}
 
-	if _, err = d.Exec(`delete from log`); err != nil {
+	if _, err = d.Exec(`DELETE FROM log`); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
This pull request updates the logic for exporting and processing user log data, focusing on improving the accuracy of room entry/exit tracking and standardizing identifiers in the CSV export functionality. The main changes involve refining SQL queries to correctly identify users' latest room status, replacing ambiguous identifiers, and improving code readability.

**Database query and logic improvements:**

* Updated the SQL query in `ForceLeave` to select only users whose most recent log entry before a given time indicates they are still in the room, improving the accuracy of force-leave operations.

**CSV export and identifier standardization:**

* Changed CSV export queries and code to use `ainsID` instead of `sid` for user identification, ensuring consistency with the database schema. [[1]](diffhunk://#diff-783daefbda219b1ee23496ba020d6c26c3be114e4e15af981ad98ab164e2fab4R19-R23) [[2]](diffhunk://#diff-783daefbda219b1ee23496ba020d6c26c3be114e4e15af981ad98ab164e2fab4L30-R43) [[3]](diffhunk://#diff-783daefbda219b1ee23496ba020d6c26c3be114e4e15af981ad98ab164e2fab4L64-R68)
* Introduced a named constant `Enter` for the enter/leave status to improve code readability and maintainability.

**Code style and consistency:**

* Standardized SQL keywords to uppercase in the log deletion statement for consistency.